### PR TITLE
Fix import errors and database path resolution

### DIFF
--- a/classroom_library_app/auth_manager.py
+++ b/classroom_library_app/auth_manager.py
@@ -1,6 +1,6 @@
 # auth_manager.py
 
-from . import student_manager # Use . to indicate relative import within the package
+import student_manager # Use . to indicate relative import within the package
 
 # Session Management Variables
 current_user_id = None


### PR DESCRIPTION
This commit addresses two issues:

1.  Resolves an `ImportError: attempted relative import with no known parent package` in `classroom_library_app/auth_manager.py`. The relative import `from . import student_manager` was changed to a direct import `import student_manager`. This aligns with how `main.py` imports modules from the same directory and ensures `auth_manager.py` can find `student_manager.py` when the application is run via `python classroom_library_app/main.py` from the project root.

2.  Corrects database path resolution in `classroom_library_app/student_manager.py`. Previously, `DB_PATH` was a hardcoded relative path ('database/library.db'), which could fail depending on the current working directory. This has been updated to use the `get_data_path` utility function (imported from `utils.py`), similar to `book_manager.py`. This makes database location robust for different execution contexts. An `os.makedirs` call was also added to the new `_get_resolved_db_path` function in `student_manager.py` to ensure the database directory exists before attempting to connect, mirroring the behavior in `book_manager.py`.

The `__init__.py` files added in the previous commit remain in place to ensure the `classroom_library_app` directory and its subdirectories are treated as packages.